### PR TITLE
Introduce `interface_name` on route item

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,7 @@
+exclude_paths:
+  - ./tests/requirements
+  - .github
+
+warn_list:
+  - experimental  # all rules tagged as experimental
+  - fqcn-builtins  # Use FQCN for builtin actions.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ The configuration is persisted within `/etc/network/{if-up.d|if-down.d}`.
 
 Use `state: absent` to remove a specific route. Routes are identified by the `network`.
 
+In some setups it may be required to override the interface_name the script is listinging to (e.g. proxmox lxc container):
+
+    ip_route_configs:
+      eth0:
+        - gateway: 172.0.1.1
+          network: 172.0.1.0/24
+          interface_name: --all
+
 ## Tags
 
 Tags can be used to limit the role execution to a particular task module. Following tags are available:

--- a/tasks/device.yml
+++ b/tasks/device.yml
@@ -4,5 +4,5 @@
     interface: "{{ interfaces | selectattr('name', 'equalto', ip_route_config.key) | first }}"
 
 - name: Configure routes
-  include: route/main.yml
+  include_tasks: route/main.yml
   with_items: "{{ ip_route_config.value }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,7 +21,7 @@
   changed_when: no
 
 - name: Configure routes for devices
-  include: device.yml
+  include_tasks: device.yml
   loop_control:
     loop_var: ip_route_config
   with_dict: "{{ ip_route_configs }}"

--- a/tasks/route/main.yml
+++ b/tasks/route/main.yml
@@ -11,9 +11,9 @@
     route_if_down_script: "/etc/network/if-down.d/{{ interface.name | regex_replace('\\.', '-') }}-{{ route_id }}"
 
 - name: Create route
-  include: create.yml
+  include_tasks: create.yml
   when: route_state == 'present'
 
 - name: Delete route
-  include: delete.yml
+  include_tasks: delete.yml
   when: route_state != 'present'

--- a/templates/if-down.j2
+++ b/templates/if-down.j2
@@ -2,6 +2,6 @@
 
 {{ ansible_managed|comment }}
 
-if [ "$IFACE" = "{{ interface.name }}" ]; then
+if [ "$IFACE" = "{{ item.interface_name | default(interface.name) }}" ]; then
     ip route del {{ item.network }}
 fi

--- a/templates/if-up.j2
+++ b/templates/if-up.j2
@@ -2,6 +2,6 @@
 
 {{ ansible_managed|comment }}
 
-if [ "$IFACE" = "{{ interface.name }}" ]; then
+if [ "$IFACE" = "{{ item.interface_name | default(interface.name) }}" ]; then
     ip route add {{ item.network }} via {{ item.gateway }} dev {{ interface.device }} proto kernel src {{ interface.ipv4.address }}
 fi


### PR DESCRIPTION
In a proxmox lxc setup you will never get a if-up for eth, because the interface is already up when the container starts.

This PR allows the change of the "trigger" interface name to ship around this issue.